### PR TITLE
Add confirmation dialog, fix my-studies route layout

### DIFF
--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -1,26 +1,41 @@
-import { useDialog } from "../../hooks";
-import { Button, Buttons } from "../Button/Button";
+import { useDialog } from '../../hooks';
+import { Button, Buttons } from '../Button/Button';
 
 export const Dialog: React.FC = () => {
-    const { title, message, confirm, cancel, visible } = useDialog();
-    const wrapperClassName = visible ? 'opacity-100 pointer-events-auto' : 'opacity-0 pointer-events-none';
-    const containerClassName = visible ? '' : 'opacity-0 translate-y-5'
+  const { title, message, confirm, cancel, visible } = useDialog();
+  const wrapperClassName = visible
+    ? 'opacity-100 pointer-events-auto'
+    : 'opacity-0 pointer-events-none';
+  const containerClassName = visible ? '' : 'opacity-0 translate-y-5';
 
-    return (
-      <div className={ `fixed inset-0 flex justify-center items-center transition-opacity ease-out duration-300 ${ wrapperClassName }` }>
-        <div className={ `absolute inset-0 bg-black opacity-25` }></div>
-        <div className={ `relative bg-white rounded transition-all duration-300 ${ containerClassName }` }>
-            <div className="p-8 space-y-4 text-center">
-                <h2 className="h2">{ title }</h2>
-                <p>{ message }</p>
-            </div>
-            <div className="p-4 border-t border-t-borders flex justify-end">
-                <Buttons>
-                    <Button style="secondary" onClick={ () => { cancel() } }>Cancel</Button>
-                    <Button onClick={ () => { confirm() }}>Confirm</Button>
-                </Buttons>
-            </div>
+  return (
+    <div
+      className={`fixed inset-0 flex items-center justify-center transition-opacity duration-300 ease-out ${wrapperClassName}`}>
+      <div className={`absolute inset-0 bg-black opacity-25`}></div>
+      <div
+        className={`relative rounded bg-white transition-all duration-300 ${containerClassName}`}>
+        <div className="space-y-4 p-8 text-center">
+          <h2 className="h2">{title}</h2>
+          <p>{message}</p>
+        </div>
+        <div className="flex justify-end border-t border-t-borders p-4">
+          <Buttons>
+            <Button
+              style="secondary"
+              onClick={() => {
+                cancel();
+              }}>
+              Cancel
+            </Button>
+            <Button
+              onClick={() => {
+                confirm();
+              }}>
+              Confirm
+            </Button>
+          </Buttons>
         </div>
       </div>
-    );
-  }
+    </div>
+  );
+};

--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -1,0 +1,26 @@
+import { useDialog } from "../../hooks";
+import { Button, Buttons } from "../Button/Button";
+
+export const Dialog: React.FC = () => {
+    const { title, message, confirm, cancel, visible } = useDialog();
+    const wrapperClassName = visible ? 'opacity-100 pointer-events-auto' : 'opacity-0 pointer-events-none';
+    const containerClassName = visible ? '' : 'opacity-0 translate-y-5'
+
+    return (
+      <div className={ `fixed inset-0 flex justify-center items-center transition-opacity ease-out duration-300 ${ wrapperClassName }` }>
+        <div className={ `absolute inset-0 bg-black opacity-25` }></div>
+        <div className={ `relative bg-white rounded transition-all duration-300 ${ containerClassName }` }>
+            <div className="p-8 space-y-4 text-center">
+                <h2 className="h2">{ title }</h2>
+                <p>{ message }</p>
+            </div>
+            <div className="p-4 border-t border-t-borders flex justify-end">
+                <Buttons>
+                    <Button style="secondary" onClick={ () => { cancel() } }>Cancel</Button>
+                    <Button onClick={ () => { confirm() }}>Confirm</Button>
+                </Buttons>
+            </div>
+        </div>
+      </div>
+    );
+  }

--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -1,4 +1,4 @@
-import { Authorize, Breadcrumbs, Header, Wrapper } from '..';
+import { Authorize, Breadcrumbs, Dialog, Header, Wrapper } from '..';
 
 export const Layout: React.FC<React.PropsWithChildren> = ({ children }) => {
   return (
@@ -10,6 +10,7 @@ export const Layout: React.FC<React.PropsWithChildren> = ({ children }) => {
             <Breadcrumbs />
             {children}
           </div>
+          <Dialog />
         </Authorize>
       </Wrapper>
     </>

--- a/src/components/StudyTable/useStudyColumns.tsx
+++ b/src/components/StudyTable/useStudyColumns.tsx
@@ -6,7 +6,7 @@ import { useMemo } from 'react';
 import type { CellProps, Column } from 'react-table';
 import type { TableItemAction } from '..';
 import { TableItemActions } from '..';
-import { useLoader, useUserRole } from '../../hooks';
+import { useDialog, useLoader, useUserRole } from '../../hooks';
 import { api } from '../../utils/api';
 
 export const useStudyColumns = () => {
@@ -15,6 +15,7 @@ export const useStudyColumns = () => {
   const { data: sessionData } = useSession();
   const myId = sessionData?.user.id;
   const myRole = useUserRole(myId ?? '');
+  const { show: showDialog } = useDialog();
 
   const deleteStudy = api.study.delete.useMutation({
     onSuccess: async () => {
@@ -95,12 +96,19 @@ export const useStudyColumns = () => {
               label: 'Delete',
               style: 'primary',
               onClick: item => {
-                start();
-                try {
-                  deleteStudy.mutate({ id: item.id });
-                } catch {
-                  stop();
-                }
+                console.log('click');
+                showDialog({
+                  title: 'Are you sure?',
+                  message: 'Are you sure you want to delete this item?',
+                  onConfirm: () => {
+                    start();
+                    try {
+                      deleteStudy.mutate({ id: item.id });
+                    } catch {
+                      stop();
+                    }
+                  },
+                });
               },
             });
           }

--- a/src/components/StudyTable/useStudyColumns.tsx
+++ b/src/components/StudyTable/useStudyColumns.tsx
@@ -96,7 +96,6 @@ export const useStudyColumns = () => {
               label: 'Delete',
               style: 'primary',
               onClick: item => {
-                console.log('click');
                 showDialog({
                   title: 'Are you sure?',
                   message: 'Are you sure you want to delete this item?',

--- a/src/components/UserTable/useUserColumns.tsx
+++ b/src/components/UserTable/useUserColumns.tsx
@@ -6,9 +6,10 @@ import type { CellProps, Column } from 'react-table';
 import { api } from '../../utils/api';
 import type { TableItemAction } from '../Table/TableItemActions';
 import { TableItemActions } from '../Table/TableItemActions';
-import { useLoader, useUserRole } from '../../hooks';
+import { useDialog, useLoader, useUserRole } from '../../hooks';
 
 export const useUserColumns = () => {
+  const { show: showDialog } = useDialog();
   const { data: sessionData } = useSession();
   const myId = sessionData?.user.id;
   const myRole = useUserRole(myId ?? '');
@@ -71,8 +72,18 @@ export const useUserColumns = () => {
               label: 'Delete',
               style: 'primary',
               onClick: item => {
-                start();
-                deleteUser.mutate({ id: item.id });
+                showDialog({
+                  title: 'Are you sure?',
+                  message: 'Are you sure you want to delete this item?',
+                  onConfirm: () => {
+                    start();
+                    try {
+                      deleteUser.mutate({ id: item.id });
+                    } catch {
+                      stop();
+                    }
+                  },
+                });
               },
             });
           }

--- a/src/components/index.tsx
+++ b/src/components/index.tsx
@@ -1,6 +1,7 @@
 export * from './Authorize/Authorize';
 export * from './Breadcrumbs/Breadcrumbs';
 export * from './Button/Button';
+export * from './Dialog/Dialog';
 export * from './Header/Header';
 export * from './Heading/Heading';
 export * from './List/List';

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,6 +1,7 @@
-export { useBreadcrumbs } from './useBreadcrumbs/useBreadcrumbs';
-export { useCreateStudy } from './useCreateStudy/useCreateStudy';
-export { useLoader } from './useLoader/useLoader';
-export { useUpdateStudy } from './useUpdateStudy/useUpdateStudy';
-export { useUserStudies } from './useUserStudies/useUserStudies';
-export { useUserRole } from './useUserRole/useUserRole';
+export * from './useBreadcrumbs/useBreadcrumbs';
+export * from './useCreateStudy/useCreateStudy';
+export * from './useDialog/useDialog';
+export * from './useLoader/useLoader';
+export * from './useUpdateStudy/useUpdateStudy';
+export * from './useUserStudies/useUserStudies';
+export * from './useUserRole/useUserRole';

--- a/src/hooks/useDialog/useDialog.tsx
+++ b/src/hooks/useDialog/useDialog.tsx
@@ -1,0 +1,34 @@
+import { create } from 'zustand'
+
+type DialogProps = {
+    title: string,
+    message: string,
+    onConfirm?: () => void,
+    onCancel?: () => void,
+}
+
+type useDialogState = DialogProps & { 
+    visible: boolean,  
+    confirm: () => void,
+    cancel: () => void,
+    show: ( props: DialogProps ) => void,
+}
+
+export const useDialog = create<useDialogState>((set) => ({
+    title: '',
+    message: '',
+    onConfirm: () => { return },
+    onCancel: () => { return },
+    confirm: () => set( state => { 
+        state.onConfirm && state.onConfirm(); 
+        return { ...state, visible: false };
+    } ),
+    cancel: () =>   set( state => {
+        state.onCancel && state.onCancel();
+        return { ...state, visible: false };
+      }),
+    visible: false,
+    show: ( { title, message, onConfirm, onCancel }: DialogProps ) => {
+        set( { title, message, onConfirm, onCancel, visible: true } ) 
+    },
+}));

--- a/src/hooks/useDialog/useDialog.tsx
+++ b/src/hooks/useDialog/useDialog.tsx
@@ -1,34 +1,40 @@
-import { create } from 'zustand'
+import { create } from 'zustand';
 
 type DialogProps = {
-    title: string,
-    message: string,
-    onConfirm?: () => void,
-    onCancel?: () => void,
-}
+  title: string;
+  message: string;
+  onConfirm?: () => void;
+  onCancel?: () => void;
+};
 
-type useDialogState = DialogProps & { 
-    visible: boolean,  
-    confirm: () => void,
-    cancel: () => void,
-    show: ( props: DialogProps ) => void,
-}
+type useDialogState = DialogProps & {
+  visible: boolean;
+  confirm: () => void;
+  cancel: () => void;
+  show: (props: DialogProps) => void;
+};
 
-export const useDialog = create<useDialogState>((set) => ({
-    title: '',
-    message: '',
-    onConfirm: () => { return },
-    onCancel: () => { return },
-    confirm: () => set( state => { 
-        state.onConfirm && state.onConfirm(); 
-        return { ...state, visible: false };
-    } ),
-    cancel: () =>   set( state => {
-        state.onCancel && state.onCancel();
-        return { ...state, visible: false };
-      }),
-    visible: false,
-    show: ( { title, message, onConfirm, onCancel }: DialogProps ) => {
-        set( { title, message, onConfirm, onCancel, visible: true } ) 
-    },
+export const useDialog = create<useDialogState>()(set => ({
+  title: '',
+  message: '',
+  onConfirm: () => {
+    return;
+  },
+  onCancel: () => {
+    return;
+  },
+  confirm: () =>
+    set(state => {
+      state.onConfirm && state.onConfirm();
+      return { ...state, visible: false };
+    }),
+  cancel: () =>
+    set(state => {
+      state.onCancel && state.onCancel();
+      return { ...state, visible: false };
+    }),
+  visible: false,
+  show: ({ title, message, onConfirm, onCancel }: DialogProps) => {
+    set({ title, message, onConfirm, onCancel, visible: true });
+  },
 }));

--- a/src/pages/studies/my-studies.tsx
+++ b/src/pages/studies/my-studies.tsx
@@ -1,7 +1,7 @@
 import { type NextPage } from 'next';
 import { useSession } from 'next-auth/react';
 
-import { Authorize, Header, StudyTable, Wrapper } from '../../components';
+import { Layout, StudyTable } from '../../components';
 import { api } from '../../utils/api';
 
 const useMyStudies = () => {
@@ -34,15 +34,10 @@ const MyStudies: NextPage = () => {
   const studies = useMyStudies();
 
   return (
-    <>
-      <Header />
-      <Wrapper className="py-14">
-        <Authorize>
-          <h1 className="h1 mb-12">My studies</h1>
-          <StudyTable data={studies} />
-        </Authorize>
-      </Wrapper>
-    </>
+    <Layout>
+      <h1 className="h1 mb-12">My studies</h1>
+      <StudyTable data={studies} />
+    </Layout>
   );
 };
 


### PR DESCRIPTION
For some reason, the `Dialog` component missed the train to this repo. I cherry-picked the commit adding this component, fixed some conflicts and then addressed #16. The root of the problem was that `src/pages/studies/my-studies` wasn't using the `Layout` component which renders the main elements of the layout of a page, including the `Dialog` component